### PR TITLE
ci: exclude data-raw from lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,2 @@
+linters: linters_with_defaults()
+exclusions: list("data-raw")


### PR DESCRIPTION
## Summary
- Add `.lintr` config file that excludes `data-raw/` from linting
- `data-raw/` contains one-time data preparation scripts, not production code
- Fixes the `code-quality` CI workflow failure caused by lint issues in data-raw files

## Test plan
- [ ] Verify `code-quality` workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)